### PR TITLE
Quantum state to quantum state base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 0.0.5
+- fix update_quantum_state type, enable to use DensityMatrix class
+
 ## 0.0.4
 - Reorganized type definition dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qulacs-wasm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Qulacs WebAssembly version",
   "main": "lib/bundle/index.js",
   "scripts": {

--- a/sample/node/src/index.ts
+++ b/sample/node/src/index.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Worker } from "worker_threads";
-import { initQulacs } from "qulacs-wasm";
+import { initQulacs, QuantumState } from "qulacs-wasm";
 
 const USE_WORKER = false;
 if (USE_WORKER) {
@@ -17,7 +17,7 @@ if (USE_WORKER) {
 } else {
     initQulacs()
         .then(async () => {
-            const { QuantumState, QuantumCircuit } = await import("qulacs-wasm");
+            const {  QuantumCircuit } = await import("qulacs-wasm");
             const state = new QuantumState(3);
             const circuit = new QuantumCircuit(3);
             circuit.add_X_gate(0);

--- a/src-ts/main/type/QulacsClass.ts
+++ b/src-ts/main/type/QulacsClass.ts
@@ -1,4 +1,3 @@
-import { QuantumState } from "../instance";
 import { Complex } from "./common";
 
 export interface QuantumStateBase {}

--- a/src-ts/main/type/QulacsClass.ts
+++ b/src-ts/main/type/QulacsClass.ts
@@ -58,7 +58,7 @@ export type DensityMatrixImpl = QuantumStateBase & {
 
 export interface QuantumCircuitImpl {
     new (qubit_count: number): QuantumCircuitImpl;
-    update_quantum_state(state: QuantumState, start_index?: number, end_index?: number): void;
+    update_quantum_state(state: QuantumStateBase, start_index?: number, end_index?: number): void;
     to_string(): string;
     copy(): QuantumCircuitImpl;
     add_gate(gate: QuantumGateBase, index?: number): void;
@@ -118,7 +118,7 @@ export interface ParametricQuantumCircuitImpl extends QuantumCircuitImpl {
 }
 
 export interface QuantumGateBase {
-    update_quantum_state(state: QuantumState): void;
+    update_quantum_state(state: QuantumStateBase): void;
     to_string(): string;
     copy(): QuantumGateMatrix;
     get_matrix(): Complex[][];


### PR DESCRIPTION
update_quantum_state()` method could not accept a DensityMatrix class.
This is a bug in the type definition and will be fixed.